### PR TITLE
Add missing platform parameter

### DIFF
--- a/lib/live_view/live_view.dart
+++ b/lib/live_view/live_view.dart
@@ -220,6 +220,7 @@ class LiveView {
         '_csrf_token': _csrf,
         '_mounts': mount.toString(),
         'client_id': _clientId,
+        '_platform': 'flutter',
         '_lvn': {'format': 'flutter', 'os': getPlatformName()},
         'vsn': '2.0.0'
       };


### PR DESCRIPTION
The `_platform` parameter is required by the server, to use the right render formmat.