### PR TITLE
Remove Phoenix Socket as direct dependency

### DIFF
--- a/lib/live_view/live_socket.dart
+++ b/lib/live_view/live_socket.dart
@@ -1,0 +1,103 @@
+import 'package:liveview_flutter/live_view/socket/channel.dart';
+import 'package:liveview_flutter/live_view/socket/message.dart';
+import 'package:liveview_flutter/live_view/socket/socket.dart';
+import 'package:phoenix_socket/phoenix_socket.dart';
+
+class LiveChannelImpl implements LiveChannel {
+  PhoenixChannel channel;
+  LiveChannelImpl({required this.channel});
+
+  @override
+  String get topic => channel.topic;
+
+  @override
+  Map<String, dynamic> get parameters => channel.parameters;
+
+  @override
+  Stream<LiveMessage> get messages {
+    return channel.messages.map(
+      (message) => LiveMessage(
+        event: message.event.value,
+        payload: message.payload,
+        topic: message.topic,
+        ref: message.ref,
+      ),
+    );
+  }
+
+  @override
+  Future<void> join() async {
+    if (channel.state != PhoenixChannelState.joined) {
+      await channel.join().future;
+    }
+  }
+
+  @override
+  Future<void> push(
+    String event, [
+    Map<String, dynamic> payload = const {},
+  ]) async {
+    if (channel.state != PhoenixChannelState.closed) {
+      await channel.push(event, payload).future;
+    }
+  }
+
+  @override
+  Future<void> close() async {
+    channel.close();
+  }
+}
+
+class LiveSocketImpl implements LiveSocket {
+  late PhoenixSocket phoenixSocket;
+  String _url = '';
+
+  @override
+  String get url => _url;
+
+  @override
+  Future<void> create({
+    required String url,
+    Map<String, dynamic>? params,
+    Map<String, String>? headers,
+  }) async {
+    _url = url;
+    phoenixSocket = PhoenixSocket(
+      url,
+      socketOptions: PhoenixSocketOptions(
+        params: params,
+        headers: headers,
+        reconnectDelays: const [
+          Duration.zero,
+          Duration(milliseconds: 1000),
+          Duration(milliseconds: 2000),
+          Duration(milliseconds: 4000),
+          Duration(milliseconds: 8000),
+        ],
+      ),
+    );
+  }
+
+  @override
+  Future<void> connect() async {
+    await phoenixSocket.connect();
+  }
+
+  @override
+  LiveChannel addChannel({
+    required String topic,
+    Map<String, dynamic>? parameters,
+  }) {
+    final channel = phoenixSocket.addChannel(
+      topic: topic,
+      parameters: parameters,
+    );
+
+    return LiveChannelImpl(channel: channel);
+  }
+
+  @override
+  Future<void> close() async {
+    phoenixSocket.close();
+  }
+}

--- a/lib/live_view/socket/channel.dart
+++ b/lib/live_view/socket/channel.dart
@@ -1,0 +1,16 @@
+import 'package:liveview_flutter/live_view/socket/message.dart';
+
+abstract class LiveChannel {
+  Stream<LiveMessage> get messages;
+  String get topic;
+  Map<String, dynamic> get parameters;
+
+  Future<void> join();
+
+  Future<void> push(
+    String event, [
+    Map<String, dynamic> payload = const {},
+  ]);
+
+  Future<void> close();
+}

--- a/lib/live_view/socket/message.dart
+++ b/lib/live_view/socket/message.dart
@@ -1,0 +1,13 @@
+class LiveMessage {
+  LiveMessage({
+    required this.event,
+    this.payload,
+    this.topic,
+    this.ref,
+  });
+
+  final String event;
+  final Map<String, dynamic>? payload;
+  final String? topic;
+  final String? ref;
+}

--- a/lib/live_view/socket/socket.dart
+++ b/lib/live_view/socket/socket.dart
@@ -1,0 +1,19 @@
+import 'package:liveview_flutter/live_view/socket/channel.dart';
+
+abstract class LiveSocket {
+  String get url;
+
+  Future<void> create({
+    required String url,
+    Map<String, dynamic>? params,
+    Map<String, String>? headers,
+  });
+
+  Future<void> connect();
+  Future<void> close();
+
+  LiveChannel addChannel({
+    required String topic,
+    Map<String, dynamic>? parameters,
+  });
+}

--- a/test/events/phx_before_each_render_test.dart
+++ b/test/events/phx_before_each_render_test.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:liveview_flutter/live_view/live_view.dart';
+import 'package:liveview_flutter/live_view/socket/message.dart';
 import 'package:liveview_flutter/live_view/ui/components/live_link.dart';
-import 'package:phoenix_socket/phoenix_socket.dart';
 
 import '../test_helpers.dart';
 
@@ -21,7 +21,7 @@ main() async {
         reason: "the theme has been set to white by phx-before-each-render");
 
     await tester.tap(find.byType(LiveLink));
-    view.handleMessage(Message(event: PhoenixChannelEvent('phx_close')));
+    view.handleMessage(LiveMessage(event: 'phx_close'));
 
     view.handleRenderedMessage({
       's': [

--- a/test/forms/http_post_test.dart
+++ b/test/forms/http_post_test.dart
@@ -1,8 +1,8 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:liveview_flutter/live_view/live_view.dart';
+import 'package:liveview_flutter/live_view/socket/message.dart';
 import 'package:liveview_flutter/live_view/ui/components/live_elevated_button.dart';
-import 'package:phoenix_socket/phoenix_socket.dart';
 
 import '../test_helpers.dart';
 
@@ -79,7 +79,7 @@ main() async {
     await tester.pumpAndSettle();
     await tester.tap(find.byType(LiveElevatedButton));
     await tester.pumpAndSettle();
-    view.handleMessage(Message(event: PhoenixChannelEvent('phx_close')));
+    view.handleMessage(LiveMessage(event: 'phx_close'));
     await tester.pumpAndSettle();
 
     expect(find.allTexts(), ['thanks for sign-in in']);

--- a/test/navigation/go_back_test.dart
+++ b/test/navigation/go_back_test.dart
@@ -1,8 +1,8 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:liveview_flutter/live_view/live_view.dart';
+import 'package:liveview_flutter/live_view/socket/message.dart';
 import 'package:liveview_flutter/live_view/ui/components/live_link.dart';
 import 'package:liveview_flutter/live_view/ui/components/live_text.dart';
-import 'package:phoenix_socket/phoenix_socket.dart';
 
 import '../test_helpers.dart';
 
@@ -27,7 +27,7 @@ main() async {
     await tester.tap(find.byType(LiveLink));
 
     expect(server.lastChannelActions, [liveEvents.join, liveEvents.phxLeave]);
-    view.handleMessage(Message(event: PhoenixChannelEvent('phx_close')));
+    view.handleMessage(LiveMessage(event: 'phx_close'));
     expect(server.lastChannelActions, [liveEvents.join]);
 
     view.handleRenderedMessage({
@@ -38,10 +38,10 @@ main() async {
     await tester.tap(find.byType(LiveText));
 
     expect(server.lastChannelActions, [liveEvents.join, liveEvents.phxLeave]);
-    view.handleMessage(Message(event: PhoenixChannelEvent('phx_close')));
+    view.handleMessage(LiveMessage(event: 'phx_close'));
     expect(server.lastChannelActions, [liveEvents.join]);
 
-    expect((server.liveSocket?.navigationLogs), [
+    expect((server.navigationLogs), [
       {'url': 'http://localhost:9999/', 'redirect': null},
       {'url': null, 'redirect': 'http://localhost:9999/second-page'},
       {'url': null, 'redirect': 'http://localhost:9999/'},

--- a/test/navigation/live_reload_test.dart
+++ b/test/navigation/live_reload_test.dart
@@ -1,7 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:liveview_flutter/live_view/live_view.dart';
+import 'package:liveview_flutter/live_view/socket/message.dart';
 import 'package:liveview_flutter/live_view/ui/components/live_link.dart';
-import 'package:phoenix_socket/phoenix_socket.dart';
 
 import '../test_helpers.dart';
 
@@ -16,8 +16,7 @@ main() async {
 
     expect(find.firstText(), 'my page');
 
-    view.handleLiveReloadMessage(
-        Message(event: PhoenixChannelEvent.custom('assets_change')));
+    view.handleLiveReloadMessage(LiveMessage(event: 'assets_change'));
 
     await tester.pumpAndSettle();
 
@@ -61,7 +60,7 @@ main() async {
 
     await tester.tap(find.byType(LiveLink));
 
-    view.handleMessage(Message(event: PhoenixChannelEvent('phx_close')));
+    view.handleMessage(LiveMessage(event: 'phx_close'));
 
     view.handleRenderedMessage({
       's': ['<Text>second page</Text>']
@@ -73,8 +72,7 @@ main() async {
 
     // we receive this event 3 times from the server
     for (var i = 0; i < 3; i++) {
-      view.handleLiveReloadMessage(
-          Message(event: PhoenixChannelEvent.custom('assets_change')));
+      view.handleLiveReloadMessage(LiveMessage(event: 'assets_change'));
     }
 
     await tester.pumpAndSettle();
@@ -97,8 +95,11 @@ main() async {
       'GET http://localhost:9999/flutter/themes/default/light.json'
     ]);
 
-    expect(server.lastChannel?.parameters['redirect'],
-        'http://localhost:9999/second-page');
+    expect(server.navigationLogs, [
+      {'url': 'http://localhost:9999/', 'redirect': null},
+      {'url': null, 'redirect': 'http://localhost:9999/second-page'},
+      {'url': 'http://localhost:9999/second-page', 'redirect': null},
+    ]);
     expect(view.router.pages.last.page.name, '/second-page');
   });
 }

--- a/test/navigation/transitions_test.dart
+++ b/test/navigation/transitions_test.dart
@@ -2,8 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:golden_toolkit/golden_toolkit.dart';
 import 'package:liveview_flutter/live_view/live_view.dart';
+import 'package:liveview_flutter/live_view/socket/message.dart';
 import 'package:liveview_flutter/live_view/ui/components/live_link.dart';
-import 'package:phoenix_socket/phoenix_socket.dart';
 
 import '../test_helpers.dart';
 
@@ -46,7 +46,7 @@ main() async {
     expect(view.router.pages.map((p) => p.page.name),
         ['loading', '/', 'loading;/second-page']);
 
-    view.handleMessage(Message(event: PhoenixChannelEvent('phx_close')));
+    view.handleMessage(LiveMessage(event: 'phx_close'));
     view.handleRenderedMessage({
       's': [
         """


### PR DESCRIPTION
This will allow us to abandon Phoenix Socket in the future, or if the user wants to use their own socket implementation.