### PR TITLE
Use the latest phoenix-socket-dart package

### DIFF
--- a/lib/live_view/live_view.dart
+++ b/lib/live_view/live_view.dart
@@ -45,14 +45,14 @@ enum ViewType { deadView, liveView }
 class LiveSocket {
   PhoenixSocket create({
     required String url,
-    required Map<String, dynamic>? params,
-    required Map<String, String>? headers,
+    required Map<String, dynamic> params,
+    required Map<String, String> headers,
   }) {
     return PhoenixSocket(
       url,
       webSocketChannelFactory: (uri) {
         final queryParams = qs.Decoder().convert(uri.query).entries.toList();
-        queryParams.addAll(params?.entries.toList() ?? []);
+        queryParams.addAll(params.entries.toList());
         final query = qs.Encoder().convert(Map.fromEntries(queryParams));
         final newUri = uri.replace(query: query).toString();
 

--- a/lib/live_view/live_view.dart
+++ b/lib/live_view/live_view.dart
@@ -45,8 +45,8 @@ enum ViewType { deadView, liveView }
 class LiveSocket {
   PhoenixSocket create({
     required String url,
-    Map<String, dynamic>? params,
-    Map<String, String>? headers,
+    required Map<String, dynamic>? params,
+    required Map<String, String>? headers,
   }) {
     return PhoenixSocket(
       url,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -280,30 +280,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.1+1"
-  leak_tracker:
-    dependency: transitive
-    description:
-      name: leak_tracker
-      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
-      url: "https://pub.dev"
-    source: hosted
-    version: "10.0.0"
-  leak_tracker_flutter_testing:
-    dependency: transitive
-    description:
-      name: leak_tracker_flutter_testing
-      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.1"
-  leak_tracker_testing:
-    dependency: transitive
-    description:
-      name: leak_tracker_testing
-      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.1"
   lints:
     dependency: transitive
     description:
@@ -324,26 +300,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
+      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16+1"
+    version: "0.12.16"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.5.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
+      sha256: a6e590c838b18133bb482a2745ad77c5bb7715fb0451209e1a7567d416678b8e
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.10.0"
   nested:
     dependency: transitive
     description:
@@ -364,10 +340,10 @@ packages:
     dependency: transitive
     description:
       name: path
-      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
+      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.8.3"
   path_provider:
     dependency: transitive
     description:
@@ -435,12 +411,11 @@ packages:
   phoenix_socket:
     dependency: "direct main"
     description:
-      path: "."
-      ref: HEAD
-      resolved-ref: "1309a1a69a681a43bf8fde46eae3c410c6241965"
-      url: "https://github.com/alex-min/phoenix-socket-dart.git"
-    source: git
-    version: "0.6.4"
+      name: phoenix_socket
+      sha256: "21c0ed733db29a74d54f676aaab4800d8b7278bc0e4e95a7a7c5d7773464a2bf"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.1"
   platform:
     dependency: transitive
     description:
@@ -686,14 +661,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
-  vm_service:
+  web:
     dependency: transitive
     description:
-      name: vm_service
-      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
+      name: web
+      sha256: afe077240a270dcfd2aafe77602b4113645af95d0ad31128cc02bce5ac5d5152
       url: "https://pub.dev"
     source: hosted
-    version: "13.0.0"
+    version: "0.3.0"
   web_socket_channel:
     dependency: "direct main"
     description:
@@ -727,5 +702,5 @@ packages:
     source: hosted
     version: "5.4.1"
 sdks:
-  dart: ">=3.2.0-134.1.beta <4.0.0"
+  dart: ">=3.2.0-194.0.dev <4.0.0"
   flutter: ">=3.10.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,9 +39,7 @@ dependencies:
   html: ^0.15.4
   web_socket_channel: ^2.4.0
   uuid: ^4.1.0
-  phoenix_socket:
-    git:
-      url: https://github.com/alex-min/phoenix-socket-dart.git
+  phoenix_socket: ^0.7.1
   xml:
   provider: ^6.0.5
   flutter_form_builder: ^9.1.1

--- a/test/test_helpers.dart
+++ b/test/test_helpers.dart
@@ -182,8 +182,8 @@ class FakeLiveSocket extends LiveSocket {
   @override
   PhoenixSocket create({
     required String url,
-    required Map<String, dynamic>? params,
-    required Map<String, String>? headers,
+    required Map<String, dynamic> params,
+    required Map<String, String> headers,
   }) {
     var socket = FakePhoenixSocket(url, PhoenixSocketOptions());
     socketsOpened.add(socket);

--- a/test/test_helpers.dart
+++ b/test/test_helpers.dart
@@ -182,8 +182,8 @@ class FakeLiveSocket extends LiveSocket {
   @override
   PhoenixSocket create({
     required String url,
-    Map<String, dynamic>? params,
-    Map<String, String>? headers,
+    required Map<String, dynamic>? params,
+    required Map<String, String>? headers,
   }) {
     var socket = FakePhoenixSocket(url, PhoenixSocketOptions());
     socketsOpened.add(socket);

--- a/test/test_helpers.dart
+++ b/test/test_helpers.dart
@@ -180,16 +180,12 @@ class FakeLiveSocket extends LiveSocket {
   List<http.Request> httpRequestsMade = [];
 
   @override
-  PhoenixSocket create(
-      {required String url,
-      required Map<String, dynamic>? params,
-      required Map<String, String>? headers}) {
-    var socket = FakePhoenixSocket(
-        url,
-        PhoenixSocketOptions(
-          params: params,
-          headers: headers,
-        ));
+  PhoenixSocket create({
+    required String url,
+    Map<String, dynamic>? params,
+    Map<String, String>? headers,
+  }) {
+    var socket = FakePhoenixSocket(url, PhoenixSocketOptions());
     socketsOpened.add(socket);
     return socket;
   }


### PR DESCRIPTION
In the new version of phoenix-socket-dart, we can define a custom websocket factory. So we don't need to maintain a custom implementation to add header support.

Additionally, in the latest version we have some fixes that ensure that the client will reconnect correctly.