### PR TITLE
Add support to data-confirm for phx-click

### DIFF
--- a/lib/exec/exec.dart
+++ b/lib/exec/exec.dart
@@ -7,9 +7,25 @@ class Exec {
   When conditions = When();
 }
 
+class DataConfirm {
+  final String title;
+  final String message;
+  final String confirm;
+  final String cancel;
+
+  DataConfirm({
+    required this.message,
+    String? title,
+    String? confirm,
+    String? cancel,
+  })  : title = title ?? 'Confirm?',
+        confirm = confirm ?? 'Ok',
+        cancel = cancel ?? 'Cancel';
+}
+
 class ExecConfirmable extends Exec {
   /// This is responsible for show an alert before executing this action
-  final String? dataConfirm;
+  final DataConfirm? dataConfirm;
   ExecConfirmable({this.dataConfirm});
 }
 

--- a/lib/exec/exec.dart
+++ b/lib/exec/exec.dart
@@ -7,4 +7,10 @@ class Exec {
   When conditions = When();
 }
 
+class ExecConfirmable extends Exec {
+  /// This is responsible for show an alert before executing this action
+  final String? dataConfirm;
+  ExecConfirmable({this.dataConfirm});
+}
+
 class ExecNoAction extends Exec {}

--- a/lib/exec/exec_live_event.dart
+++ b/lib/exec/exec_live_event.dart
@@ -1,9 +1,14 @@
 import 'package:liveview_flutter/exec/exec.dart';
 
-class ExecLiveEvent extends Exec {
+class ExecLiveEvent extends ExecConfirmable {
   final String type;
   final String name;
   final dynamic value;
 
-  ExecLiveEvent({required this.type, required this.name, required this.value});
+  ExecLiveEvent({
+    required this.type,
+    required this.name,
+    required this.value,
+    super.dataConfirm,
+  });
 }

--- a/lib/exec/flutter_exec.dart
+++ b/lib/exec/flutter_exec.dart
@@ -61,7 +61,15 @@ class FlutterExecAction {
           type: 'phx-click',
           name: value!['name'],
           value: getPhxValues(attributes),
-          dataConfirm: attributes?['data-confirm'],
+          dataConfirm:
+              (attributes?['data-confirm'] as String?)?.isNotEmpty == true
+                  ? DataConfirm(
+                      message: attributes!['data-confirm'],
+                      title: attributes['data-confirm-title'],
+                      cancel: attributes['data-confirm-cancel'],
+                      confirm: attributes['data-confirm-confirm'],
+                    )
+                  : null,
         );
       })
       ..add(['live-patch'], (value, attributes) {

--- a/lib/exec/flutter_exec.dart
+++ b/lib/exec/flutter_exec.dart
@@ -58,9 +58,11 @@ class FlutterExecAction {
     LiveViewExecRegistry.instance
       ..add(['phx-click'], (value, attributes) {
         return ExecLiveEvent(
-            type: 'phx-click',
-            name: value!['name'],
-            value: getPhxValues(attributes));
+          type: 'phx-click',
+          name: value!['name'],
+          value: getPhxValues(attributes),
+          dataConfirm: attributes?['data-confirm'],
+        );
       })
       ..add(['live-patch'], (value, attributes) {
         return ExecLivePatch(url: value!['name']);
@@ -73,16 +75,23 @@ class FlutterExecAction {
       })
       ..add(['goBack'], (_, __) => ExecGoBack())
       ..add(['switchTheme'], (value, attributes) {
-        return ExecSwitchTheme(theme: value!['theme'], mode: value['mode']);
+        return ExecSwitchTheme(
+          theme: value!['theme'],
+          mode: value['mode'],
+        );
       })
       ..add(['saveCurrentTheme'], (_, __) => ExecSaveCurrentTheme())
       ..add(['show'], (value, attributes) {
         return ExecShowAction(
-            to: value?['to'], timeInMilliseconds: value?['time']);
+          to: value?['to'],
+          timeInMilliseconds: value?['time'],
+        );
       })
       ..add(['hide'], (value, attributes) {
         return ExecHideAction(
-            to: value?['to'], timeInMilliseconds: value?['time']);
+          to: value?['to'],
+          timeInMilliseconds: value?['time'],
+        );
       })
       ..add(['showBottomSheet'], (_, __) => ExecShowBottomSheet());
   }

--- a/lib/live_view/state/computed_attributes.dart
+++ b/lib/live_view/state/computed_attributes.dart
@@ -13,6 +13,9 @@ mixin ComputedAttributes {
     'phx-href',
     'phx-before-each-render',
     'data-confirm',
+    'data-confirm-title',
+    'data-confirm-cancel',
+    'data-confirm-confirm',
     'self-padding',
     'self-margin'
   ];

--- a/lib/live_view/state/computed_attributes.dart
+++ b/lib/live_view/state/computed_attributes.dart
@@ -12,6 +12,7 @@ mixin ComputedAttributes {
     'live-patch',
     'phx-href',
     'phx-before-each-render',
+    'data-confirm',
     'self-padding',
     'self-margin'
   ];

--- a/lib/live_view/state/events.dart
+++ b/lib/live_view/state/events.dart
@@ -88,21 +88,21 @@ class StateEvents {
   }
 
   static EventHandler confirmationWrapper(Exec action, EventHandler handler) {
-    if (action is ExecConfirmable && action.dataConfirm?.isNotEmpty == true) {
+    if (action is ExecConfirmable && action.dataConfirm != null) {
       return (context) => showDialog(
             context: context,
             builder: (context) => AlertDialog(
-              title: const Text("Confirm?"),
-              content: Text(action.dataConfirm!),
+              title: Text(action.dataConfirm!.title),
+              content: Text(action.dataConfirm!.message),
               actions: [
                 TextButton(
-                  child: const Text('Cancel'),
+                  child: Text(action.dataConfirm!.cancel),
                   onPressed: () {
                     Navigator.of(context).pop();
                   },
                 ),
                 TextButton(
-                  child: const Text('Confirm'),
+                  child: Text(action.dataConfirm!.confirm),
                   onPressed: () {
                     Navigator.of(context).pop(true);
                   },

--- a/test/events/phx_click_test.dart
+++ b/test/events/phx_click_test.dart
@@ -67,7 +67,13 @@ main() async {
 
     view.handleRenderedMessage({
       's': [
-        '<Text phx-click="click_event" data-confirm="Are you sure?">hello</Text>'
+        """<Text
+              phx-click="click_event"
+              data-confirm="This action cannot be undone!"
+              data-confirm-title="Are you sure?"
+              data-confirm-confirm="Confirm"
+              data-confirm-cancel="Cancel"
+          >hello</Text>"""
       ]
     });
     await tester.pumpAndSettle();

--- a/test/events/phx_click_test.dart
+++ b/test/events/phx_click_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:golden_toolkit/golden_toolkit.dart';
 import 'package:liveview_flutter/live_view/live_view.dart';
 import 'package:liveview_flutter/live_view/ui/components/live_text.dart';
 
@@ -56,5 +57,35 @@ main() async {
     await tester.tap(find.text("Page 4"));
     expect(server.lastChannelActions?.last,
         liveEvents.phxClick({'something': 'hello'}, eventName: 'my_event'));
+  });
+
+  testWidgets('phx click on a text component', (tester) async {
+    await loadAppFonts();
+    var (view, server) = await connect(LiveView());
+
+    await tester.runLiveView(view);
+
+    view.handleRenderedMessage({
+      's': [
+        '<Text phx-click="click_event" data-confirm="Are you sure?">hello</Text>'
+      ]
+    });
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byType(LiveText));
+    await tester.pumpAndSettle();
+    expect(server.lastChannelActions?.last, isNot(liveEvents.phxClick({})));
+
+    await tester.tap(find.text("Cancel"));
+    await tester.pumpAndSettle();
+    expect(server.lastChannelActions?.last, isNot(liveEvents.phxClick({})));
+
+    await tester.tap(find.byType(LiveText));
+    await tester.pumpAndSettle();
+    expect(server.lastChannelActions?.last, isNot(liveEvents.phxClick({})));
+
+    await tester.tap(find.text("Confirm"));
+    await tester.pumpAndSettle();
+    expect(server.lastChannelActions?.last, liveEvents.phxClick({}));
   });
 }


### PR DESCRIPTION
This will show a dialog that requestes the user confirmation when a widget with data-confirm attribute is taped.

https://hexdocs.pm/phoenix_live_view/Phoenix.Component.html#link/1-data-attributes

## Usage

Simple:
```heex
<Text phx-click="click_event" data-confirm="Are you sure?">Delete</Text>
```
Custom:
```heex
<Text
    phx-click="click_event"
    data-confirm="This action cannot be undone!"
    data-confirm-title="Are you sure?"
    data-confirm-confirm="Yes, delete!"
    data-confirm-cancel="Cancel"
>Delete</Text>
```