### PR TITLE
Add support to border and border radius decoration

### DIFF
--- a/lib/live_view/mapping/border.dart
+++ b/lib/live_view/mapping/border.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+import 'package:liveview_flutter/live_view/mapping/edge_colors.dart';
+import 'package:liveview_flutter/live_view/mapping/edge_insets.dart';
+
+Border? getBorder(BuildContext context, String? border) {
+  var exp = RegExp(
+    r'^((?:\d+\s?)+)((?:(?:[@a-z\.]+\s?)|(?:#[a-f0-9]+\s?))*)$',
+    caseSensitive: false,
+  );
+  if (border == null || !exp.hasMatch(border)) {
+    return null;
+  }
+
+  var match = exp.firstMatch(border)!;
+  var widths = match[0];
+  var colors = match[1];
+
+  var edgesWidths = getEdgeInsets(widths);
+
+  if (edgesWidths == null) {
+    return null;
+  }
+
+  var edgesColors = getEdgeColors(context, colors);
+
+  return Border(
+    top: BorderSide(width: edgesWidths.top, color: edgesColors.top),
+    right: BorderSide(width: edgesWidths.right, color: edgesColors.right),
+    bottom: BorderSide(width: edgesWidths.bottom, color: edgesColors.bottom),
+    left: BorderSide(width: edgesWidths.left, color: edgesColors.left),
+  );
+}

--- a/lib/live_view/mapping/border_radius.dart
+++ b/lib/live_view/mapping/border_radius.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+import 'package:liveview_flutter/live_view/mapping/edge_insets.dart';
+
+BorderRadius? getBorderRadius(String? borderRadio) {
+  var edges = getEdgeInsets(borderRadio);
+
+  if (edges == null) {
+    return null;
+  }
+
+  return BorderRadius.only(
+    topLeft: Radius.circular(edges.top),
+    topRight: Radius.circular(edges.right),
+    bottomRight: Radius.circular(edges.bottom),
+    bottomLeft: Radius.circular(edges.left),
+  );
+}

--- a/lib/live_view/mapping/decoration.dart
+++ b/lib/live_view/mapping/decoration.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:liveview_flutter/live_view/mapping/border.dart';
+import 'package:liveview_flutter/live_view/mapping/border_radius.dart';
 import 'package:liveview_flutter/live_view/mapping/colors.dart';
 import 'package:liveview_flutter/live_view/mapping/css.dart';
 
@@ -8,12 +10,23 @@ Decoration? getDecoration(BuildContext context, String? css) {
   }
 
   Color? color;
+  BorderRadius? borderRadius;
+  Border? border;
 
   for (var (prop, value) in parseCss(css)) {
     switch (prop) {
       case 'background':
         color = getColor(context, value);
+      case 'border-radius':
+        borderRadius = getBorderRadius(value);
+      case 'border':
+        border = getBorder(context, value);
     }
   }
-  return BoxDecoration(color: color);
+
+  return BoxDecoration(
+    color: color,
+    borderRadius: borderRadius,
+    border: border,
+  );
 }

--- a/lib/live_view/mapping/edge_colors.dart
+++ b/lib/live_view/mapping/edge_colors.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart';
+import 'package:liveview_flutter/live_view/mapping/colors.dart';
+
+EdgeColors getEdgeColors(BuildContext context, String? borderColors) {
+  if (borderColors == null) {
+    return EdgeColors.zero;
+  }
+
+  var values = borderColors.split(' ');
+
+  var top = values[0];
+  var right = values.elementAtOrNull(1) ?? top;
+  var bottom = values.elementAtOrNull(2) ?? top;
+  var left = values.elementAtOrNull(3) ?? right;
+
+  return EdgeColors(
+    top: getColor(context, top) ?? const Color(0xFF000000),
+    right: getColor(context, right) ?? const Color(0xFF000000),
+    bottom: getColor(context, bottom) ?? const Color(0xFF000000),
+    left: getColor(context, left) ?? const Color(0xFF000000),
+  );
+}
+
+class EdgeColors {
+  final Color top;
+  final Color right;
+  final Color bottom;
+  final Color left;
+
+  const EdgeColors({
+    required this.top,
+    required this.right,
+    required this.bottom,
+    required this.left,
+  });
+
+  const EdgeColors.all(Color value)
+      : left = value,
+        top = value,
+        right = value,
+        bottom = value;
+
+  const EdgeColors.only({
+    this.left = Colors.black,
+    this.top = Colors.black,
+    this.right = Colors.black,
+    this.bottom = Colors.black,
+  });
+
+  const EdgeColors.symmetric({
+    Color vertical = Colors.black,
+    Color horizontal = Colors.black,
+  })  : left = horizontal,
+        top = vertical,
+        right = horizontal,
+        bottom = vertical;
+
+  static const EdgeColors zero = EdgeColors.all(Colors.black);
+
+  @override
+  int get hashCode => Object.hash(top, right, bottom, left);
+
+  @override
+  bool operator ==(Object other) =>
+      other is EdgeColors &&
+      other.top == top &&
+      other.right == right &&
+      other.bottom == bottom &&
+      other.left == left;
+
+  @override
+  String toString() {
+    return 'EdgeColors(top: $top, right: $right, bottom: $bottom, left: $left)';
+  }
+}

--- a/lib/live_view/mapping/edge_insets.dart
+++ b/lib/live_view/mapping/edge_insets.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+import 'package:liveview_flutter/live_view/ui/utils.dart';
+
+EdgeInsets? getEdgeInsets(String? edges) {
+  if (edges == null) {
+    return null;
+  }
+  edges = edges.trim();
+  if (!edges.matches(r'^[\d\s]+$')) {
+    return null;
+  }
+  if (edges == '0') {
+    return EdgeInsets.zero;
+  }
+
+  var values = edges
+      .replaceAll(RegExp(r'\s+'), ' ')
+      .replaceAll(RegExp(r'[^\d\s]'), '')
+      .split(' ')
+      .map((e) => double.tryParse(e))
+      .toList();
+
+  if (values.any((e) => e == null)) {
+    return null;
+  }
+
+  var top = values[0] ?? 0.0;
+  var right = values.elementAtOrNull(1) ?? top;
+  var bottom = values.elementAtOrNull(2) ?? top;
+  var left = values.elementAtOrNull(3) ?? right;
+
+  return EdgeInsets.only(top: top, left: left, right: right, bottom: bottom);
+}

--- a/test/mapping/edge_colors_test.dart
+++ b/test/mapping/edge_colors_test.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:liveview_flutter/live_view/mapping/edge_colors.dart';
+
+void main() {
+  testWidgets('material text style', (tester) async {
+    await tester.pumpWidget(
+      Builder(
+        builder: (BuildContext context) {
+          expect(
+            getEdgeColors(context, ""),
+            const EdgeColors.all(Colors.black),
+          );
+          expect(
+            getEdgeColors(context, "red"),
+            const EdgeColors.all(Colors.red),
+          );
+          expect(
+            getEdgeColors(context, "red blue"),
+            const EdgeColors.symmetric(
+              vertical: Colors.red,
+              horizontal: Colors.blue,
+            ),
+          );
+          expect(
+            getEdgeColors(context, "red blue green"),
+            const EdgeColors.only(
+              top: Colors.red,
+              right: Colors.blue,
+              bottom: Colors.green,
+              left: Colors.blue,
+            ),
+          );
+          expect(
+            getEdgeColors(context, "red blue green pink"),
+            const EdgeColors.only(
+              top: Colors.red,
+              right: Colors.blue,
+              bottom: Colors.green,
+              left: Colors.pink,
+            ),
+          );
+
+          return const SizedBox.shrink();
+        },
+      ),
+    );
+  });
+}

--- a/test/mapping/edge_insets_test.dart
+++ b/test/mapping/edge_insets_test.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/painting.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:liveview_flutter/live_view/mapping/edge_insets.dart';
+
+void main() {
+  test('common cases', () {
+    expect(getEdgeInsets(""), null);
+    expect(getEdgeInsets("10"), const EdgeInsets.all(10));
+    expect(
+      getEdgeInsets("10 0"),
+      const EdgeInsets.symmetric(
+        vertical: 10,
+        horizontal: 0,
+      ),
+    );
+    expect(
+      getEdgeInsets("10 0 5"),
+      const EdgeInsets.only(
+        top: 10,
+        right: 0,
+        bottom: 5,
+        left: 0,
+      ),
+    );
+    expect(
+      getEdgeInsets("10 2 5"),
+      const EdgeInsets.only(
+        top: 10,
+        right: 2,
+        bottom: 5,
+        left: 2,
+      ),
+    );
+    expect(
+      getEdgeInsets("10 1 5 8"),
+      const EdgeInsets.only(
+        top: 10,
+        right: 1,
+        bottom: 5,
+        left: 8,
+      ),
+    );
+  });
+}


### PR DESCRIPTION
This is following the MDN specs:

https://developer.mozilla.org/en-US/docs/Web/CSS/border

Border only supports:

```
/* width */
border: 2;
border: 2 2;
border: 2 2 2;
border: 2 2 2 2;

/* width | style */
border: 2 red;
border: 2 red red;
border: 2 red red red;
border: 2 red red red red;
```